### PR TITLE
Cmake install and scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Makefile
 cmake_install.cmake
 compile_commands.json
 codebrowser_*
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,12 @@ add_definitions(-fno-strict-aliasing)
 add_subdirectory(generator)
 add_subdirectory(indexgenerator)
 
+configure_file(FindWoboq.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/FindWoboq.cmake @ONLY)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/FindWoboq.cmake
+    DESTINATION share/woboq/cmake)
+
 install(DIRECTORY data
     DESTINATION share/woboq
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 2.8)
+
+# gcc 6.2 complains a lot about type-prunning in llvm-headers... feels kinda
+# scary, so buy the silence with a few percent less of a speed:
+add_definitions(-fno-strict-aliasing)
+
 add_subdirectory(generator)
 add_subdirectory(indexgenerator)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 add_subdirectory(generator)
 add_subdirectory(indexgenerator)
+
+install(DIRECTORY data
+    DESTINATION share/woboq
+    )

--- a/FindWoboq.cmake.in
+++ b/FindWoboq.cmake.in
@@ -70,12 +70,10 @@ function(_woboqCreateNewGeneratorTarget)
     # does not play well with the global "woboq" and "woboq-serve" targets
     set(outdir ${WOBOQ_OUTDIR})
 
-    # this will (?) retrieve where the CMakeLists of this target is located. I
-    # think this is what the second part of the "-p" switch needs...
+    # this retrieves where the CMakeLists of this target is located. Will use
+    # this directory as src-dir in the "-p" option for woboq:
     get_property(srcdir TARGET ${trgt} PROPERTY SOURCE_DIR)
-    # this is the "woboq" project name. we could add a version string...
-    #
-    # TODO: add current git-sha1 as revision
+    # this is the "woboq" project name TODO: add current git-sha1 as revision?
     set(srcprjct ${trgt}:${srcdir})
 
     # add a second "project" for files generated inside

--- a/FindWoboq.cmake.in
+++ b/FindWoboq.cmake.in
@@ -86,6 +86,8 @@ function(_woboqCreateNewGeneratorTarget)
 
     # the actual, precious step: run the generator
     add_custom_command(OUTPUT ${outdir}/${trgt}
+        # take care to have a clean output location:
+        COMMAND rm -rf ${outdir}/${trgt}
         # use two projects, one with the source and one with the build. the
         # second stage (indexgenerator) will figure it out later.
         COMMAND ${WOBOQ_GENERATOR} -a -b ${CMAKE_BINARY_DIR} -o ${outdir} -p ${srcprjct} -p ${bldprjct}
@@ -105,7 +107,7 @@ function(_woboqCreateNewGeneratorTarget)
 
     # add woboq files to clean target
     set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
-        ${outdir}/${trgt} ${outdir}/${PROJECT_NAME}-build)
+        ${outdir}/${trgt})
 
 endfunction()
 

--- a/FindWoboq.cmake.in
+++ b/FindWoboq.cmake.in
@@ -26,22 +26,27 @@ if("${WOBOQ_DATA}" STREQUAL "")
     message("-- woboq found in '@CMAKE_INSTALL_PREFIX@', outputting into '${WOBOQ_OUTDIR}'")
 endif()
 
-# the global target to tie everything together. not sure if all the paths are
-# correct, but seems to mostly work.
+# the global target to tie everything together by parsing all output into the
+# various index.html -- seems to mostly work.
 #
 # splitting the "data+index" step from the actual "generator" allows to add
 # content from multiple targets (invocations of the generator) into one
-# browsable "database".
+# browsable "database" with one "data" folder in the root of the dir-tree
 if(NOT TARGET woboq)
     add_custom_target(woboq
         COMMAND cp -vr ${WOBOQ_DATA} ${WOBOQ_OUTDIR}
-        COMMAND ${WOBOQ_INDEXER} ${WOBOQ_OUTDIR} -d ../data
+        COMMAND ${WOBOQ_INDEXER} ${WOBOQ_OUTDIR} -d /data
         COMMENT "provide static data and configure index.html"
         )
 endif()
 
-# a nice convenience target, so that we have a local webserver to test the
-# result.  serves directly from the build-folder:
+# also cleanup the woboq-folder when asked to:
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+    ${WOBOQ_OUTDIR}
+    )
+
+# a nice convenience target, which provides a local webserver to test the
+# result.  serves directly from the output-folder:
 if(NOT TARGET woboq-serve)
     add_custom_target(woboq-serve
         COMMAND python -m SimpleHTTPServer
@@ -69,16 +74,34 @@ function(_woboqCreateNewGeneratorTarget)
     # think this is what the second part of the "-p" switch needs...
     get_property(srcdir TARGET ${trgt} PROPERTY SOURCE_DIR)
     # this is the "woboq" project name. we could add a version string...
-    set(prjct ${trgt}:${srcdir})
+    #
+    # TODO: add current git-sha1 as revision
+    set(srcprjct ${trgt}:${srcdir})
 
-    # the actual, preciuos step: run the generator
+    # add a second "project" for files generated inside
+    # the global build directory. this will pout all generated file into a
+    # parallel page-tree in the served html.
+    get_property(blddir TARGET ${trgt} PROPERTY BINARY_DIR)
+    set(bldprjct ${trgt}-build:${blddir})
+
+    # the actual, precious step: run the generator
     add_custom_command(OUTPUT ${outdir}/${trgt}
-        COMMAND ${WOBOQ_GENERATOR} -a -b ${CMAKE_BINARY_DIR} -o ${outdir} -p ${prjct}
+        # use two projects, one with the source and one with the build. the
+        # second stage (indexgenerator) will figure it out later.
+        COMMAND ${WOBOQ_GENERATOR} -a -b ${CMAKE_BINARY_DIR} -o ${outdir} -p ${srcprjct} -p ${bldprjct}
+        # sadly, this _has_ to depend on trgt, to be sure that any generated
+        # file is present. cmake has no way to specify dependency on single
+        # files from sudirectories. this will at least not build the ALL target
+        DEPENDS ${trgt}
         )
     # wrap this into a proper target
     add_custom_target(woboq-${trgt} DEPENDS ${outdir}/${trgt})
     # and add the sub-target to the "global" woboq target
     add_dependencies(woboq woboq-${trgt})
+
+    # add woboq files to clean target
+    set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+        ${outdir}/${trgt} ${outdir}/${PROJECT_NAME}-build)
 
 endfunction()
 

--- a/FindWoboq.cmake.in
+++ b/FindWoboq.cmake.in
@@ -99,6 +99,10 @@ function(_woboqCreateNewGeneratorTarget)
     # and add the sub-target to the "global" woboq target
     add_dependencies(woboq woboq-${trgt})
 
+    install(DIRECTORY ${outdir}/${trgt}
+        DESTINATION share/doc/woboq
+        )
+
     # add woboq files to clean target
     set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
         ${outdir}/${trgt} ${outdir}/${PROJECT_NAME}-build)

--- a/FindWoboq.cmake.in
+++ b/FindWoboq.cmake.in
@@ -88,7 +88,7 @@ function(_woboqCreateNewGeneratorTarget)
         COMMAND rm -rf ${outdir}/${trgt}
         # use two projects, one with the source and one with the build. the
         # second stage (indexgenerator) will figure it out later.
-        COMMAND ${WOBOQ_GENERATOR} -a -b ${CMAKE_BINARY_DIR} -o ${outdir} -p ${srcprjct} -p ${bldprjct}
+        COMMAND ${WOBOQ_GENERATOR} -d /data -a -b ${CMAKE_BINARY_DIR} -o ${outdir} -p ${srcprjct} -p ${bldprjct}
         # sadly, this _has_ to depend on trgt, to be sure that any generated
         # file is present. cmake has no way to specify dependency on single
         # files from sudirectories. this will at least not build the ALL target

--- a/FindWoboq.cmake.in
+++ b/FindWoboq.cmake.in
@@ -82,7 +82,7 @@ function(_woboqCreateNewGeneratorTarget)
     # the global build directory. this will pout all generated file into a
     # parallel page-tree in the served html.
     get_property(blddir TARGET ${trgt} PROPERTY BINARY_DIR)
-    set(bldprjct ${trgt}-build:${blddir})
+    set(bldprjct ${trgt}/build:${blddir})
 
     # the actual, precious step: run the generator
     add_custom_command(OUTPUT ${outdir}/${trgt}

--- a/FindWoboq.cmake.in
+++ b/FindWoboq.cmake.in
@@ -1,0 +1,99 @@
+# this "lookup code" uses caching and will only be executed once
+if("${WOBOQ_DATA}" STREQUAL "")
+    # when the carnary variable WOBOQ_DATA is not set we assume that this is
+    # the first run of this script.
+    #
+    # lookup some executables. as this script will be configured by cmake
+    # during configure time, we already know where to look
+    # (CMAKE_INSTALL_PREFIX), and can thus can simplify the search:
+    find_program(WOBOQ_GENERATOR
+        codebrowser_generator
+        PATHS @CMAKE_INSTALL_PREFIX@/bin
+        NO_DEFAULT_PATH
+        "create html")
+    # same for the indexer
+    find_program(WOBOQ_INDEXER
+        codebrowser_indexgenerator
+        PATHS @CMAKE_INSTALL_PREFIX@/bin
+        NO_DEFAULT_PATH
+        "create index")
+    # the static data-files:
+    SET(WOBOQ_DATA  "@CMAKE_INSTALL_PREFIX@/share/woboq/data" CACHE INTERNAL "woboq data")
+    # and this is where we ouput into. this is a fixed location.
+    SET(WOBOQ_OUTDIR "${CMAKE_BINARY_DIR}/woboq" CACHE INTERNAL "woboq outdir")
+    # because of using the cached variable, this message will only appear once,
+    # even when the "find_package()" macro is called multiple times
+    message("-- woboq found in '@CMAKE_INSTALL_PREFIX@', outputting into '${WOBOQ_OUTDIR}'")
+endif()
+
+# the global target to tie everything together. not sure if all the paths are
+# correct, but seems to mostly work.
+#
+# splitting the "data+index" step from the actual "generator" allows to add
+# content from multiple targets (invocations of the generator) into one
+# browsable "database".
+if(NOT TARGET woboq)
+    add_custom_target(woboq
+        COMMAND cp -vr ${WOBOQ_DATA} ${WOBOQ_OUTDIR}
+        COMMAND ${WOBOQ_INDEXER} ${WOBOQ_OUTDIR} -d ../data
+        COMMENT "provide static data and configure index.html"
+        )
+endif()
+
+# a nice convenience target, so that we have a local webserver to test the
+# result.  serves directly from the build-folder:
+if(NOT TARGET woboq-serve)
+    add_custom_target(woboq-serve
+        COMMAND python -m SimpleHTTPServer
+        WORKING_DIRECTORY ${WOBOQ_OUTDIR}
+        COMMENT "serving woboq from '${WOBOQ_OUTDIR}' at http://localhost:8000"
+        DEPENDS woboq
+        )
+endif()
+
+# this internal function executes woboq for _one_ target, into a subdir of
+# WOBOQ_OUTDIR:
+function(_woboqCreateNewGeneratorTarget)
+    set(options )
+    set(multiValueArgs )
+    set(oneValueArgs TARGET)
+    cmake_parse_arguments(_woboq "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+    # create function-local variables:
+    set(trgt ${_woboq_TARGET})
+    # the outdir cannot be overridden from the outside... in theory yes, but
+    # does not play well with the global "woboq" and "woboq-serve" targets
+    set(outdir ${WOBOQ_OUTDIR})
+
+    # this will (?) retrieve where the CMakeLists of this target is located. I
+    # think this is what the second part of the "-p" switch needs...
+    get_property(srcdir TARGET ${trgt} PROPERTY SOURCE_DIR)
+    # this is the "woboq" project name. we could add a version string...
+    set(prjct ${trgt}:${srcdir})
+
+    # the actual, preciuos step: run the generator
+    add_custom_command(OUTPUT ${outdir}/${trgt}
+        COMMAND ${WOBOQ_GENERATOR} -a -b ${CMAKE_BINARY_DIR} -o ${outdir} -p ${prjct}
+        )
+    # wrap this into a proper target
+    add_custom_target(woboq-${trgt} DEPENDS ${outdir}/${trgt})
+    # and add the sub-target to the "global" woboq target
+    add_dependencies(woboq woboq-${trgt})
+
+endfunction()
+
+# the public interface:
+function(CreateBrowsableDocumentation)
+    set(options )
+    # allow calling this function with single argument or a list
+    set(multiValueArgs TARGETS)
+    set(oneValueArgs TARGET)
+    cmake_parse_arguments(_woboq "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+    # and then call the main-function for each target of the list:
+    foreach(trgt ${_woboq_TARGETS} ${_woboq_TARGET})
+        # guard against multiple calls:
+        if(NOT TARGET woboq-${trgt})
+            _woboqCreateNewGeneratorTarget(TARGET ${trgt})
+        endif()
+    endforeach()
+endfunction()

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ You need:
 
 Example:
 ```bash
-cmake . -DLLVM_CONFIG_EXECUTABLE=/opt/llvm/bin/llvm-config -DCMAKE_BUILD_TYPE=Release
-make
+mkdir -p build && cd build
+cmake .. -DLLVM_CONFIG_EXECUTABLE=llvm-config-3.8 -DCMAKE_INSTALL_PREFIX=$HOME/woboq.install -DCMAKE_BUILD_TYPE=Release
+make -j
 ```
 
 Compiling the generator on OS X

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -48,3 +48,6 @@ endforeach()
 
 configure_file(embedded_includes.h.in embedded_includes.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+install(TARGETS codebrowser_generator
+    RUNTIME DESTINATION bin)

--- a/indexgenerator/CMakeLists.txt
+++ b/indexgenerator/CMakeLists.txt
@@ -12,3 +12,6 @@ IF (APPLE)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
     SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}  -stdlib=libc++" )
 ENDIF()
+
+install(TARGETS codebrowser_indexgenerator
+    RUNTIME DESTINATION bin)


### PR DESCRIPTION
Thanks for this nice tool, worked better than I expected ;-) This PR might not be finished or polished, but might be helpful to others. It allows to

- Install the data-folder, generator and indexer programs, as well as providing a new `FindWoboq.cmake`
- Edited README for the linux installation procedure to do out-of-source builds. They are much inferior.
- Disabled strict-aliasing, as gcc6 will emit many warnings due to type-pruning in llvm headers. Can't change these. Better safe than sorry.

If `FindWoboq.cmake` is findable in `$CMAKE_MODULE_PATH`, there is a new function `CreateBrowsableDocumentation(TARGET $trgt)`. It will create targets like `woboq-$trgt`, `woboq` and `woboq-serve`. So adding the following to a CMakeLists:

    # of course, provide the correct installation location
    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "/opt/woboq.install/share/woboq/cmake")
    find_package(Woboq REQUIRED)
    CreateBrowsableDocumentation(TARGETS subtarget1 subtarget2 maintarget)
    
Then, after recreating the build-folder, start a python simple http server:

    make -C build woboq-serve

And open the stuff in the browser:

    xdg-open http://localhost:8000

Works for me ;-) The indexer seems a bit buggy or wrongly used be me -- css is broken in some locations?

Sidenote: Generated files located inside the build-folder (Qt...) are missing if the build folder is _not_ inside the src-folder. See [ProjectManager::projectForFile](https://github.com/woboq/woboq_codebrowser/blob/2618a2eaf40642e3673b4f3d0ce341ead7d21426/generator/projectmanager.cpp#L51). This is inconvenient in a CI-environment for example.