### PR TITLE
fix crash on invalid declaration references

### DIFF
--- a/generator/commenthandler.cpp
+++ b/generator/commenthandler.cpp
@@ -104,7 +104,7 @@ clang::NamedDecl *parseDeclarationReference(llvm::StringRef Text, clang::Sema &S
                             return nullptr;
                         auto Result = T2->lookup(II);
 #if CLANG_VERSION_MAJOR >= 13
-                        if (Result.isSingleResult())
+                        if (Result.empty() || Result.isSingleResult())
                             return nullptr;
 #else
                         if (Result.size() != 1)


### PR DESCRIPTION
if such decl reference is invalid, the `Result` will be empty, but a later call to `front()` asserts it to be non-empty. 