### PR TITLE
Ignore unsupported UTF-8 characters

### DIFF
--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -71,7 +71,7 @@ def do_file(directory, f, max_task):
 
     txtlines = OrderedDict()
     for fil in possible_files:
-        lines = str(fil.read_text()).splitlines()
+        lines = str(fil.read_text(errors='replace')).splitlines()
         for line in lines:
             txtlines[line] = None
 


### PR DESCRIPTION
If a file contains an unsupported UTF-8 character, it will break the full `runner.py` script.
Ignoring the unwanted characters seems to be the best solution.